### PR TITLE
Fix iterator bug in Rust IO benchmark

### DIFF
--- a/back/rust/src/io/src/main.rs
+++ b/back/rust/src/io/src/main.rs
@@ -51,9 +51,10 @@ async fn io() -> Result<(), sqlx::Error> {
             .has_headers(false)
             .from_path(&out_csv)
             .expect("IN CSV OPEN ERROR");
+        let mut wdr_records = wdr.records();
         for result in rdr.records() {
             let in_record = result.expect("IN CSV READ ERROR");
-            let out_record = wdr.records().next().expect("msg").unwrap();
+            let out_record = wdr_records.next().expect("msg").unwrap();
 
             let in_str = in_record.iter().collect::<Vec<&str>>().join(",");
             let out_str = out_record.iter().collect::<Vec<&str>>().join(",");


### PR DESCRIPTION
## Summary
- fix `wdr.records().next()` call that repeatedly restarted iterator

## Testing
- `cargo check` *(fails: cannot download crates)*

------
https://chatgpt.com/codex/tasks/task_e_683f9526a030832aa86648a0ee6dbb1b