### PR TITLE
Add setup script for React app

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -29,3 +29,20 @@ docker-compose up -d --build
 ```markdown
 docker-compose down
 ```
+
+# Setup Script
+To install Node.js and project dependencies locally, run:
+
+```bash
+./setup.sh
+```
+
+This command installs Node.js and then fetches npm dependencies for the React app.
+
+# Running Tests
+After running the setup script, execute tests from the React application directory:
+
+```bash
+cd front/react/src/react-app
+npm test
+```

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install Node.js and npm if not already installed
+if ! command -v node > /dev/null; then
+  apt-get update
+  apt-get install -y nodejs npm
+fi
+
+# Install front-end dependencies
+cd "$(dirname "$0")/front/react/src/react-app"
+npm install


### PR DESCRIPTION
## Summary
- add `setup.sh` to install Node.js and npm packages
- document how to run `setup.sh` and how to execute tests

## Testing
- `bash setup.sh` *(fails: npm install cannot fetch packages)*
- `npm test --runInBand` *(fails: `react-scripts` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fa13abb94832a8f7e2456c7f9e56e