### PR TITLE
ベンチマーク画面のUI刷新とPlaywrightブラウザ確認フローの追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+output/playwright/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# AGENTS.md
+
+## Browser Verification
+- Playwright や同等のブラウザ自動化で UI を確認する場合、`screenshot` と `snapshot` は必ず対で取得する。
+- ブラウザ確認の詳細手順、保存先、Playwright コンテナの使い方は [docs/browser-verification.md](/home/ytana/work/benchmark/docs/browser-verification.md) を参照する。

--- a/Readme.md
+++ b/Readme.md
@@ -10,10 +10,23 @@ docker-compose -f docker-compose-dev.yml up -d --build
 
 rustはサーバー起動(ビルド)に時間がかかります。ログを見て確認してください。
 
+- Playwright コンテナで UI 確認する場合
+```markdown
+docker compose -f docker-compose-dev.yml -f docker-compose.playwright.yml up -d --build
+docker compose -f docker-compose-dev.yml -f docker-compose.playwright.yml exec playwright bash
+```
+Playwright コンテナ内では、アプリ本体へ `http://proxy-nginx-dev` でアクセスできます。
+必要に応じて `npx playwright test` や Playwright CLI をそのまま実行してください。
+ブラウザ確認の運用ルールは [docs/browser-verification.md](/home/ytana/work/benchmark/docs/browser-verification.md) を参照してください。
+
 
 - 終了方法
 ```markdown
 docker-compose -f docker-compose-dev.yml down
+```
+Playwright コンテナも同時に落とす場合は以下です。
+```markdown
+docker compose -f docker-compose-dev.yml -f docker-compose.playwright.yml down
 ```
 
 

--- a/docker-compose.playwright.yml
+++ b/docker-compose.playwright.yml
@@ -1,0 +1,14 @@
+services:
+  playwright:
+    image: mcr.microsoft.com/playwright:v1.58.2-noble
+    container_name: benchmark-playwright
+    working_dir: /workspace
+    command: sleep infinity
+    shm_size: 1gb
+    volumes:
+      - ./:/workspace
+    environment:
+      BASE_URL: http://proxy-nginx-dev
+    depends_on:
+      proxy-nginx-dev:
+        condition: service_started

--- a/docs/browser-verification.md
+++ b/docs/browser-verification.md
@@ -1,0 +1,42 @@
+# Browser Verification
+
+## Purpose
+- 実ブラウザでの UI 確認を、ホスト環境を汚さずに再現可能な手順で回す。
+- 見た目確認と DOM 構造確認を分離せず、毎回セットで証跡を残す。
+
+## Artifacts
+- Playwright の成果物は `output/playwright/<label>/` 配下に保存する。
+- `screenshot` は見た目確認用の PNG として扱う。
+- `snapshot` は DOM 構造、表示テキスト、Playwright の要素参照 ID 確認用の YAML として扱う。
+- UI 確認は `screenshot` 単体、または `snapshot` 単体で完了扱いにしない。
+
+## Required Pairing
+- 初期表示確認では、ページ読み込み直後に `snapshot` と `screenshot` を両方取る。
+- ボタンクリック、入力、モーダル表示、ページ遷移などで状態が変わる確認では、変化後に `snapshot` と `screenshot` を両方取り直す。
+- 状態変化の確認では、必要に応じて操作前と操作後の 2 組を残す。
+
+## Playwright Container
+- UI 確認は Playwright 専用コンテナを優先し、ホストにブラウザや Playwright 用依存を入れない。
+- 起動:
+```bash
+docker compose -f docker-compose-dev.yml -f docker-compose.playwright.yml up -d --build
+```
+- シェルに入る:
+```bash
+docker compose -f docker-compose-dev.yml -f docker-compose.playwright.yml exec playwright bash
+```
+- コンテナ内では `http://proxy-nginx-dev` をアプリのベース URL として使う。
+
+## Playwright CLI Workflow
+- `open`
+- `snapshot`
+- `screenshot`
+- 操作
+- 必要なら待機
+- `snapshot`
+- `screenshot`
+
+## Reporting
+- ユーザーへ結果を返すときは、少なくとも最新の PNG と YAML の両方を示す。
+- YAML は全文をそのまま説明しない。確認できた事実だけを要約する。
+- 失敗時は、操作内容、見えていた UI 状態、関連するネットワークログまたはコンソールログを併記する。

--- a/front/react/src/react-app/src/App.css
+++ b/front/react/src/react-app/src/App.css
@@ -1,99 +1,366 @@
-.App {
-  text-align: left;
-  padding: 0.5rem;
-  width: 40rem;
+:root {
+  --bg: #06131f;
+  --bg-accent: #0d2133;
+  --panel: rgba(8, 24, 38, 0.82);
+  --panel-strong: rgba(11, 31, 48, 0.95);
+  --line: rgba(137, 196, 244, 0.22);
+  --line-strong: rgba(126, 199, 255, 0.45);
+  --text: #f3f8fc;
+  --muted: #93abc0;
+  --accent: #68d2ff;
+  --accent-strong: #21a6f3;
+  --success: #2dd4bf;
+  --warning: #fbbf24;
+  --danger: #fb7185;
+  --shadow: 0 24px 60px rgba(1, 11, 21, 0.45);
+  --radius-xl: 28px;
+  --radius-lg: 20px;
+  --radius-md: 14px;
 }
 
-.App-logo {
-  height: 40vmin;
+* {
+  box-sizing: border-box;
+}
+
+.app-shell {
+  position: relative;
+  min-height: 100vh;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at top left, rgba(33, 166, 243, 0.2), transparent 32%),
+    radial-gradient(circle at top right, rgba(45, 212, 191, 0.16), transparent 26%),
+    linear-gradient(180deg, #04111d 0%, #071520 48%, #091a28 100%);
+}
+
+.app-background {
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(rgba(104, 210, 255, 0.06) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(104, 210, 255, 0.06) 1px, transparent 1px);
+  background-size: 96px 96px;
+  mask-image: linear-gradient(180deg, rgba(0, 0, 0, 0.85), transparent);
   pointer-events: none;
 }
 
-@media (prefers-reduced-motion: no-preference) {
-  .App-logo {
-    animation: App-logo-spin infinite 20s linear;
-  }
+.app {
+  position: relative;
+  width: min(1180px, calc(100vw - 32px));
+  margin: 0 auto;
+  padding: 48px 0 72px;
 }
 
-.App-header {
-  background-color: #282c34;
-  min-height: 100vh;
+.hero,
+.bench-section {
+  position: relative;
+  backdrop-filter: blur(16px);
+  background: linear-gradient(180deg, rgba(14, 35, 52, 0.94), rgba(7, 21, 33, 0.9));
+  border: 1px solid var(--line);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow);
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1.7fr) minmax(280px, 0.9fr);
+  gap: 24px;
+  padding: 32px;
+  margin-bottom: 24px;
+}
+
+.hero-kicker,
+.section-kicker,
+.hero-summary-label,
+.code-panel-title,
+.bench-note-title,
+.bench-lang,
+.bench-status {
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.hero-kicker,
+.section-kicker {
+  margin: 0 0 12px;
+  color: var(--accent);
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.hero h1,
+.section-heading h2 {
+  margin: 0;
+  color: var(--text);
+  line-height: 1.05;
+}
+
+.hero h1 {
+  max-width: 12ch;
+  font-size: clamp(2.2rem, 5vw, 4.4rem);
+}
+
+.hero-description,
+.section-heading p,
+.bench-note p {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.7;
+}
+
+.hero-description {
+  max-width: 62ch;
+  margin-top: 18px;
+  font-size: 1rem;
+}
+
+.hero-summary {
+  display: grid;
+  gap: 14px;
+  align-self: stretch;
+}
+
+.hero-summary div {
   display: flex;
   flex-direction: column;
+  justify-content: space-between;
+  gap: 10px;
+  min-height: 110px;
+  padding: 20px;
+  background: linear-gradient(180deg, rgba(10, 28, 42, 0.95), rgba(5, 17, 28, 0.92));
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg);
+}
+
+.hero-summary-label {
+  color: var(--muted);
+  font-size: 0.72rem;
+  font-weight: 700;
+}
+
+.hero-summary strong {
+  color: var(--text);
+  font-size: 1.2rem;
+}
+
+.sections {
+  display: grid;
+  gap: 24px;
+}
+
+.bench-section {
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(0, 1.3fr);
+  gap: 24px;
+  padding: 28px;
+}
+
+.bench-section-copy {
+  display: grid;
+  gap: 18px;
+}
+
+.section-heading {
+  display: grid;
+  gap: 10px;
+}
+
+.section-heading h2 {
+  font-size: clamp(1.6rem, 3vw, 2.4rem);
+}
+
+.code-panel,
+.bench-note,
+.bench-card {
+  background: linear-gradient(180deg, rgba(8, 24, 38, 0.92), rgba(5, 16, 26, 0.92));
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg);
+}
+
+.code-panel {
+  padding: 18px 20px;
+}
+
+.code-panel-title,
+.bench-note-title {
+  display: block;
+  margin-bottom: 12px;
+  color: var(--accent);
+  font-size: 0.72rem;
+  font-weight: 700;
+}
+
+.code-panel pre,
+.bench-result pre {
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-family: 'IBM Plex Mono', 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+}
+
+.code-panel pre {
+  color: #d8e9f8;
+  line-height: 1.75;
+}
+
+.bench-note {
+  padding: 18px 20px;
+}
+
+.bench-note p + p {
+  margin-top: 10px;
+}
+
+.bench-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+  align-items: stretch;
+}
+
+.bench-card {
+  display: grid;
+  grid-template-rows: auto auto 1fr;
+  gap: 16px;
+  padding: 18px;
+  min-height: 280px;
+}
+
+.bench-card-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.bench-lang {
+  margin: 0;
+  color: var(--text);
+  font-size: 0.85rem;
+  font-weight: 700;
+}
+
+.bench-status {
+  display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-size: calc(10px + 2vmin);
-  color: white;
+  min-width: 78px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: rgba(147, 171, 192, 0.12);
+  color: var(--muted);
+  font-size: 0.72rem;
+  font-weight: 700;
 }
 
-.App-link {
-  color: #61dafb;
+.bench-status-loading {
+  color: var(--warning);
+  background: rgba(251, 191, 36, 0.12);
 }
 
-@keyframes App-logo-spin {
-  from {
-    transform: rotate(0deg);
+.bench-status-done {
+  color: var(--success);
+  background: rgba(45, 212, 191, 0.12);
+}
+
+.bench-status-error {
+  color: var(--danger);
+  background: rgba(251, 113, 133, 0.12);
+}
+
+.bench-button {
+  border: 0;
+  border-radius: 999px;
+  padding: 12px 16px;
+  background: linear-gradient(135deg, var(--accent) 0%, var(--accent-strong) 100%);
+  color: #03111d;
+  font-size: 0.95rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition:
+    transform 120ms ease,
+    box-shadow 120ms ease,
+    opacity 120ms ease;
+  box-shadow: 0 10px 24px rgba(33, 166, 243, 0.28);
+}
+
+.bench-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 30px rgba(33, 166, 243, 0.32);
+}
+
+.bench-button:disabled {
+  opacity: 0.7;
+  cursor: wait;
+  transform: none;
+}
+
+.bench-result {
+  min-height: 144px;
+  padding: 16px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--panel-strong);
+}
+
+.bench-result pre {
+  color: #dff3ff;
+  font-size: 0.92rem;
+  line-height: 1.6;
+}
+
+.bench-result-loading {
+  display: grid;
+  place-items: center;
+  gap: 10px;
+  text-align: center;
+}
+
+.bench-result-loading p {
+  margin: 0;
+  color: var(--muted);
+}
+
+.bench-loading {
+  width: 42px;
+  height: 42px;
+}
+
+@media (max-width: 980px) {
+  .hero,
+  .bench-section {
+    grid-template-columns: 1fr;
   }
-  to {
-    transform: rotate(360deg);
+
+  .hero h1 {
+    max-width: 14ch;
+  }
+
+  .bench-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
-.Bench {
-  display: flex;
-  margin-block-end: 2rem;
-}
+@media (max-width: 720px) {
+  .app {
+    width: min(100vw - 20px, 100%);
+    padding: 24px 0 48px;
+  }
 
-.Bench div {
-  min-width: 11rem;
-  margin: 0.5rem;
-  padding: 0.5rem;
-  border: 1px solid #000;
-  background-color: lightcyan;
-  border-radius: 0.5rem;
-  min-height: 11rem;
-}
+  .hero,
+  .bench-section {
+    padding: 20px;
+    border-radius: 24px;
+  }
 
-.Bench button {
-  border-radius: 0.5rem;
-  background-color: royalblue;
-  color: whitesmoke;
-  font-size: large;
-}
+  .hero-summary div {
+    min-height: auto;
+  }
 
-.Bench button:hover {
-  background-color: blue;
-}
+  .bench-grid {
+    grid-template-columns: 1fr;
+  }
 
-.Bench p {
-  font-size: medium;
-}
-
-.BenchDec h1{
-  margin: 0.5rem;
-}
-
-.BenchDec h2{
-  margin: 0.5rem;
-  padding: 0.5rem;
-  border: #000 solid;
-  border-radius: 1rem;
-  background-color: darkblue;
-}
-
-.BenchDec h2 p{
-  font-size: medium;
-  color: orangered;
-}
-
-.BenchDec pre{
-  margin: 0rem;
-  color: #f6f4f4;
-}
-
-.BenchDiv {
-  background-color: aqua;
-  border: #000 solid;
-  border-radius: 0.2rem;
-  margin-block-end: 0.2rem;
+  .bench-card {
+    min-height: 0;
+  }
 }

--- a/front/react/src/react-app/src/App.test.tsx
+++ b/front/react/src/react-app/src/App.test.tsx
@@ -1,9 +1,82 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+describe('App', () => {
+  beforeEach(() => {
+    jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ res: '計測結果\n123ms' }),
+    } as Response);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('主要見出しと各ベンチマークセクションを表示する', () => {
+    render(<App />);
+
+    expect(screen.getByRole('heading', { name: 'PHP / Rust / Go のベンチマークを比較する' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'ライプニッツ級数' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'フィボナッチ数列' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'I/O処理' })).toBeInTheDocument();
+    expect(document.querySelectorAll('.bench-status-idle')).toHaveLength(9);
+  });
+
+  test('各ベンチマークセクションは3言語カードを持つ', () => {
+    render(<App />);
+
+    expect(screen.getAllByText('PHP 8 JIT')).toHaveLength(3);
+    expect(screen.getAllByText('Rust')).toHaveLength(3);
+    expect(screen.getAllByText('Go')).toHaveLength(3);
+  });
+
+  test('クリックで計測中になり、完了後に結果を表示する', async () => {
+    let resolveFetch: ((value: Response) => void) | undefined;
+
+    (global.fetch as jest.Mock).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveFetch = resolve as (value: Response) => void;
+        })
+    );
+
+    render(<App />);
+
+    act(() => {
+      fireEvent.click(screen.getAllByRole('button', { name: 'Run PHP' })[0]);
+    });
+
+    expect(screen.getByText('計測中')).toBeInTheDocument();
+    expect(global.fetch).toHaveBeenCalledWith('/php/index.php?kind=pi');
+
+    await act(async () => {
+      resolveFetch?.({
+        ok: true,
+        json: async () => ({ res: '計測結果\n123ms' }),
+      } as Response);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('完了')).toBeInTheDocument();
+      expect(screen.getByText(/計測結果/)).toBeInTheDocument();
+    });
+  });
+
+  test('各 workload のリクエストURLが既存仕様のまま', async () => {
+    render(<App />);
+
+    await act(async () => {
+      fireEvent.click(screen.getAllByRole('button', { name: 'Run PHP' })[0]);
+      fireEvent.click(screen.getAllByRole('button', { name: 'Run Rust' })[1]);
+      fireEvent.click(screen.getAllByRole('button', { name: 'Run Go' })[2]);
+    });
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenNthCalledWith(1, '/php/index.php?kind=pi');
+      expect(global.fetch).toHaveBeenNthCalledWith(2, '/rust/?kind=fib');
+      expect(global.fetch).toHaveBeenNthCalledWith(3, '/golang/?kind=io');
+    });
+  });
 });

--- a/front/react/src/react-app/src/App.tsx
+++ b/front/react/src/react-app/src/App.tsx
@@ -1,145 +1,224 @@
-import React, {useState, useCallback, FC} from 'react';
+import React, { useState } from 'react';
 import './App.css';
-import loading_img from './loading.gif';
+import loadingImg from './loading.gif';
 
+type BenchKind = 'pi' | 'fib' | 'io';
+type BenchLang = 'php' | 'rust' | 'go';
+type BenchStatus = 'idle' | 'loading' | 'done' | 'error';
 
-function doBenche(kind:string, lang:string, callback:React.Dispatch<React.SetStateAction<string>>) {
-    var url = "";
-    if (lang == "php") {
-        url += "/php/index.php?kind=" + kind;
-    } else if (lang == "go") {
-        url += "/golang/?kind=" + kind;
-    } else if (lang == "rust") {
-        url += "/rust/?kind=" + kind;
-    }
-    fetch(url)
-    .then(
-        res => {
-            console.log(res);
-            return res.json();
-        }
-    ).then(
-        data => {
-            console.log(data);
-            callback(data.res);
-        }
-    );
-    return;
-} 
+type BenchDefinition = {
+  kind: BenchKind;
+  title: string;
+  summary: string;
+  details: string[];
+  notes?: string[];
+};
 
-const BenchResult = ({ result }: {result:string}) => {
-    if (result == "計測中・・・") {
-        return (
-            <>
-            <p></p>
-            <img src={loading_img}></img>
-            </>
-        )
-    }
-    const texts = result.split(/(\n)/).map((item, index) => {
-      return (
-        <React.Fragment key={index}>
-          { item.match(/\n/) ? <br /> : item }
-        </React.Fragment>
-      );
-    });
+type BenchResponse = {
+  res: string;
+};
+
+const languageMeta: Record<BenchLang, { label: string; button: string }> = {
+  php: { label: 'PHP 8 JIT', button: 'Run PHP' },
+  rust: { label: 'Rust', button: 'Run Rust' },
+  go: { label: 'Go', button: 'Run Go' },
+};
+
+const benchDefinitions: BenchDefinition[] = [
+  {
+    kind: 'pi',
+    title: 'ライプニッツ級数',
+    summary: '単純ループで円周率に近似し、純粋な計算処理の速度を比較します。',
+    details: ['[(-1)^n / (2n+1)]', 'n=0 から 100000000 まで累計し、最後に 4 を掛ける'],
+  },
+  {
+    kind: 'fib',
+    title: 'フィボナッチ数列',
+    summary: '再帰呼び出しのオーバーヘッドが出やすい処理で、実装系ごとの差を見ます。',
+    details: [
+      'function getFib(int $n): int {',
+      '  return $n < 2 ? $n : getFib($n - 1) + getFib($n - 2);',
+      '}',
+      'getFib(40);',
+    ],
+  },
+  {
+    kind: 'io',
+    title: 'I/O処理',
+    summary: 'CSV の読み書きと DB insert を繰り返し、単純計算以外の負荷を比較します。',
+    details: [
+      'input_file: 1レコード int 型 5カラム、200レコードの CSV',
+      'CSV を DB(MySQL) に insert',
+      'insert したデータを CSV に書き出し',
+      '書き出した CSV とインプットファイルのレコードを比較',
+      '以上を 5 回繰り返す',
+    ],
+    notes: [
+      'Rust と Go は I/O 制御を非同期で実装しているため、1スレッド限定条件では非同期オーバーヘッドの影響が出ます。',
+      'Rust は同期実装も可能ですが、この条件では PHP と大きく異ならない想定です。',
+    ],
+  },
+];
+
+function getBenchUrl(kind: BenchKind, lang: BenchLang): string {
+  if (lang === 'php') {
+    return `/php/index.php?kind=${kind}`;
+  }
+
+  if (lang === 'go') {
+    return `/golang/?kind=${kind}`;
+  }
+
+  return `/rust/?kind=${kind}`;
+}
+
+async function runBench(kind: BenchKind, lang: BenchLang): Promise<string> {
+  const response = await fetch(getBenchUrl(kind, lang));
+
+  if (!response.ok) {
+    throw new Error(`Request failed with status ${response.status}`);
+  }
+
+  const data: BenchResponse = await response.json();
+  return data.res;
+}
+
+function formatResult(result: string): string[] {
+  return result
+    .split('\n')
+    .map((line) => line.trimEnd())
+    .filter((line, index, array) => line.length > 0 || index < array.length - 1);
+}
+
+function BenchResult({ status, result }: { status: BenchStatus; result: string }) {
+  if (status === 'loading') {
     return (
-        <>
-        <p>{texts}</p>
-        </>
+      <div className="bench-result bench-result-loading" aria-live="polite">
+        <img className="bench-loading" src={loadingImg} alt="計測中" />
+        <p>ベンチマークを実行しています...</p>
+      </div>
     );
   }
 
-const Func = ( {kind,lang}:{kind:string,lang:string} )  => {
-    const [result, setResult] = useState("未計測")
+  const lines = formatResult(result);
 
-    const onClickButton = () => {
-        setResult("計測中・・・");
-        doBenche(kind,lang,setResult);
-    }
-
-
-    var button_str = "";
-    switch (lang) {
-        case "php":
-            button_str = 'PHP8-JIT Start';
-            break;
-        case "go":
-            button_str = 'golang Start';
-            break;
-        case "rust":
-            button_str = 'rust Start';
-            break;
-    }
-    return (
-        <div>
-            <button onClick={onClickButton}>{button_str}</button>
-            <BenchResult result={result}/>
-        </div>
-
-    );
-};
-
-const App: React.FC = () => {
-    return (
-        <div className="App">
-            <div className="BenchDiv">
-                <div className='BenchDec'>
-                    <h1>ライプニッツ級数(単純ループ計算処理)</h1>
-                    <h2>
-                        <pre>
-                            {"[(-1)^n / (2n+1)]"}<br/>
-                            {"↑をn=0～100000000まで累計して X 4"}<br/>
-                        </pre>
-                    </h2>
-                </div>
-                <div className="Bench">
-                    <Func kind="pi" lang="php" />
-                    <Func kind="pi" lang="rust" />
-                    <Func kind="pi" lang="go" />
-                </div>
-            </div>
-            <div className="BenchDiv">
-                <div className='BenchDec'>
-                    <h1>フィボナッチ数列(再帰呼び出し)</h1>
-                    <h2>
-                        <pre>
-                            {"function getFib(int $n): int {"}<br/>
-                            {"    return $n < 2 ? $n : getFib($n - 1) + getFib($n - 2);"}<br/>
-                            {"}"}<br/>
-                            {"getFib(40);"}<br/>
-                        </pre>
-                    </h2>
-                </div>
-                <div className="Bench">
-                    <Func kind="fib" lang="php" />
-                    <Func kind="fib" lang="rust" />
-                    <Func kind="fib" lang="go" />
-                </div>
-            </div>
-            <div className="BenchDiv">
-                <div className='BenchDec'>
-                    <h1>I/O処理</h1>
-                    <h2>
-                        <pre>
-                            {"input_file: 1レコード:int型:5カラム 200レコードのcsv"}<br/><br/>
-                            {"上記CSVをDB(mysql)にinsert (トランザクション制御なし)"}<br/>
-                            {"insertしたデータをcsvに書き出し"}<br/>
-                            {"書き出したcsvとインプットファイルのレコード比較"}<br/>
-                            {"以上を5回繰り返す"}<br/>
-                        </pre>
-                        <p>※rustおよびgolangはi/o制御を非同期で実装しているため、このベンチ(1スレッド限定条件)では非同期オーバーヘッドの影響が出ています。</p>                        
-                        <p>rustは同期実装も可能なので、将来的にはそちらでも比較してみたいが、phpと速度結果は大きく変わらないはず。</p>
-                    </h2>
-                </div>
-                <div className="Bench">
-                    <Func kind="io" lang="php" />
-                    <Func kind="io" lang="rust" />
-                    <Func kind="io" lang="go" />
-                </div>
-            </div>
-        </div>
-    )
+  return (
+    <div className="bench-result" aria-live="polite">
+      <pre>{lines.join('\n')}</pre>
+    </div>
+  );
 }
- 
-export default App
+
+function BenchCard({ kind, lang }: { kind: BenchKind; lang: BenchLang }) {
+  const [status, setStatus] = useState<BenchStatus>('idle');
+  const [result, setResult] = useState('未計測');
+
+  const handleClick = async () => {
+    setStatus('loading');
+    setResult('計測中...');
+
+    try {
+      const nextResult = await runBench(kind, lang);
+      setResult(nextResult);
+      setStatus('done');
+    } catch (error) {
+      console.error(error);
+      setResult('計測に失敗しました。時間をおいて再実行してください。');
+      setStatus('error');
+    }
+  };
+
+  const statusLabel =
+    status === 'idle'
+      ? '未計測'
+      : status === 'loading'
+        ? '計測中'
+        : status === 'done'
+          ? '完了'
+          : 'エラー';
+
+  return (
+    <article className="bench-card">
+      <div className="bench-card-head">
+        <p className="bench-lang">{languageMeta[lang].label}</p>
+        <span className={`bench-status bench-status-${status}`}>{statusLabel}</span>
+      </div>
+      <button type="button" className="bench-button" onClick={handleClick} disabled={status === 'loading'}>
+        {languageMeta[lang].button}
+      </button>
+      <BenchResult status={status} result={result} />
+    </article>
+  );
+}
+
+function BenchSection({ definition }: { definition: BenchDefinition }) {
+  return (
+    <section className="bench-section">
+      <div className="bench-section-copy">
+        <div className="section-heading">
+          <p className="section-kicker">Benchmark</p>
+          <h2>{definition.title}</h2>
+          <p>{definition.summary}</p>
+        </div>
+        <div className="code-panel">
+          <div className="code-panel-title">処理概要</div>
+          <pre>{definition.details.join('\n')}</pre>
+        </div>
+        {definition.notes && (
+          <div className="bench-note">
+            <p className="bench-note-title">補足</p>
+            {definition.notes.map((note) => (
+              <p key={note}>{note}</p>
+            ))}
+          </div>
+        )}
+      </div>
+      <div className="bench-grid">
+        {(['php', 'rust', 'go'] as BenchLang[]).map((lang) => (
+          <BenchCard key={lang} kind={definition.kind} lang={lang} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function App() {
+  return (
+    <main className="app-shell">
+      <div className="app-background" aria-hidden="true" />
+      <div className="app">
+        <header className="hero">
+          <div className="hero-copy">
+            <p className="hero-kicker">Language Benchmark Dashboard</p>
+            <h1>PHP / Rust / Go のベンチマークを比較する</h1>
+            <p className="hero-description">
+              単純計算、再帰、I/O の 3 パターンで実行時間を比較し、各ランタイムの特性を同じ UI 上で確認できます。
+            </p>
+          </div>
+          <div className="hero-summary">
+            <div>
+              <span className="hero-summary-label">対象</span>
+              <strong>3 workloads</strong>
+            </div>
+            <div>
+              <span className="hero-summary-label">比較言語</span>
+              <strong>PHP / Rust / Go</strong>
+            </div>
+            <div>
+              <span className="hero-summary-label">実行方式</span>
+              <strong>個別スタート</strong>
+            </div>
+          </div>
+        </header>
+
+        <div className="sections">
+          {benchDefinitions.map((definition) => (
+            <BenchSection key={definition.kind} definition={definition} />
+          ))}
+        </div>
+      </div>
+    </main>
+  );
+}
+
+export default App;

--- a/front/react/src/react-app/src/index.css
+++ b/front/react/src/react-app/src/index.css
@@ -1,13 +1,23 @@
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
+  font-family: 'Space Grotesk', 'Avenir Next', 'Segoe UI', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  background: #06131f;
+  color: #f3f8fc;
 }
 
 code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
-    monospace;
+  font-family: 'IBM Plex Mono', 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+}
+
+button,
+input,
+textarea,
+select {
+  font: inherit;
+}
+
+#root {
+  min-height: 100vh;
 }


### PR DESCRIPTION
## 概要
- ベンチマーク画面をダッシュボード風の UI に刷新
- React 側をデータ定義ベースの構造に整理
- Playwright 用コンテナとブラウザ確認手順を追加
- Playwright の成果物を git 管理対象外に設定

## 変更内容
- 単一画面の UI を再設計
  - ヒーロー領域の追加
  - ベンチマークごとのセクションカード化
  - 言語ごとの比較カード化
  - `未計測 / 計測中 / 完了 / エラー` の状態表示を明確化
  - PC / スマホ両対応のレスポンシブレイアウトへ変更
- バックエンド API の URL とレスポンス仕様は維持
- CRA 初期テストを置き換え、以下を確認するテストを追加
  - 見出しと各ベンチマークセクションの表示
  - 各 workload に 3 言語カードがあること
  - ローディングから結果表示までの状態変化
  - 既存リクエスト URL の回帰確認
- `docker-compose.playwright.yml` を追加し、専用 Playwright コンテナで UI 確認できるようにした
- ブラウザ確認ルールを以下に追加
  - `AGENTS.md`
  - `docs/browser-verification.md`
- `output/playwright/` を `.gitignore` に追加

## 動作確認
- フロントエンドのテスト成功
  - `docker compose -f docker-compose-dev.yml run --rm --no-deps front-react-dev sh -lc 'cd /usr/src/app/react-app && npm test -- --watchAll=false'`
- フロントエンドのビルド成功
  - `docker compose -f docker-compose-dev.yml run --rm --no-deps front-react-dev sh -lc 'cd /usr/src/app/react-app && npm run build'`
- Playwright コンテナ経由の UI 確認成功
  - `http://proxy-nginx-dev` を開いて初期表示確認
  - 先頭の `Run PHP` ボタンをクリック
  - UI が `未計測` から `完了` に変化することを確認
  - `GET /php/index.php?kind=pi` が `200 OK` で返ることを確認

## 補足
- push のため、Git remote は HTTPS から SSH に切り替え
- Playwright の screenshot / snapshot 成果物は git 管理対象外